### PR TITLE
Skip arrays while merging context

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/frctl/handlebars",
   "dependencies": {
-    "@frctl/fractal": "^1.0.0",
+    "@frctl/fractal": "^1.1.0",
     "bluebird": "^3.4.1",
     "handlebars": "^4.0.5",
     "lodash": "^4.12.0",

--- a/src/helpers/render.js
+++ b/src/helpers/render.js
@@ -2,6 +2,7 @@
 
 const Handlebars = require('handlebars');
 const _          = require('lodash');
+const utils      = require('@frctl/fractal').utils;
 
 module.exports = function(fractal){
 
@@ -27,7 +28,7 @@ module.exports = function(fractal){
         if (!context) {
             context = defaultContext;
         } else if (merge) {
-            context = _.defaultsDeep(context, defaultContext);
+            context = utils.defaultsDeep(context, defaultContext);
         }
         
         return source.resolve(context).then(context => {


### PR DESCRIPTION
In an attempt to fix frctl/fractal#123 (comment), I propose to use Fractal own defaultsDeep method to avoid merging the content of arrays while merging contexts.

I had to bump the minimal Fractal version since this method is available only since version 1.1.0.

See also https://github.com/frctl/nunjucks/pull/6