### PR TITLE
Skip arrays while merging context (bis)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "promised-handlebars": "^2.0.0"
   },
   "peerDependencies": {
-    "@frctl/fractal": "^1.0.0"
+    "@frctl/fractal": "^1.1.0"
   },
   "devDependencies": {}
 }

--- a/src/helpers/render.js
+++ b/src/helpers/render.js
@@ -2,6 +2,7 @@
 
 const Handlebars = require('handlebars');
 const _          = require('lodash');
+const utils      = require('@frctl/fractal').utils;
 
 module.exports = function(fractal){
 
@@ -27,7 +28,7 @@ module.exports = function(fractal){
         if (!context) {
             context = defaultContext;
         } else if (merge) {
-            context = _.defaultsDeep(context, defaultContext);
+            context = utils.defaultsDeep(context, defaultContext);
         }
         
         return source.resolve(context).then(context => {


### PR DESCRIPTION
This is a copy of #1 since I accidentally deleted the fork repository.

The fractal dependency has been bumped because `defaultsDeep` only exists since version 1.1.